### PR TITLE
Use newly available compilers for CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
             cxx: g++-12
             packages: gcc-12 g++-12
             os: ubuntu-22.04
+          - compiler: gcc-14
+            cxx: g++-14
+            packages: gcc-14 g++-14
+            os: ubuntu-24.04
         exclude:
           - compiler: gcc-7
             cppVersion: 20
@@ -92,6 +96,10 @@ jobs:
           - compiler: clang++-15
             os: ubuntu-22.04
             packages: clang-15 lld-15
+            enable_file_prefix_map: true
+          - compiler: clang++-18
+            os: ubuntu-24.04
+            packages: clang-18 lld-18
             enable_file_prefix_map: true
         exclude:
           - compiler: clang++-7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        compiler: [gcc-12, gcc-7]
+        compiler: [gcc-12, gcc-7, gcc-14]
         cppVersion: [17, 20]
         include:
           - compiler: gcc-7
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         cppVersion: [17, 20]
-        compiler: [clang++-7, clang++-15]
+        compiler: [clang++-7, clang++-15, clang++-18]
         include:
           - compiler: clang++-7
             os: ubuntu-20.04


### PR DESCRIPTION
Use GCC 14 and Clang 18 available on ubuntu 24.04 CI runners.